### PR TITLE
added summaries for alert messages and bumped version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.graylog.plugins</groupId>
     <artifactId>graylog-plugin-slack</artifactId>
-    <version>2.2.2-SNAPSHOT</version>
+    <version>2.2.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginBase.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginBase.java
@@ -7,6 +7,7 @@ import org.graylog2.plugin.configuration.ConfigurationRequest;
 import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.TextField;
+import org.graylog2.plugin.configuration.fields.NumberField;
 import org.graylog2.plugin.streams.Stream;
 
 import java.net.URI;
@@ -31,6 +32,7 @@ public class SlackPluginBase {
     public static final String CK_ICON_EMOJI = "icon_emoji";
     public static final String CK_GRAYLOG2_URL = "graylog2_url";
     public static final String CK_COLOR = "color";
+    public static final String CK_ADD_BLITEMS = "backlog_items";
 
     public static ConfigurationRequest configuration() {
         final ConfigurationRequest configurationRequest = new ConfigurationRequest();
@@ -57,6 +59,11 @@ public class SlackPluginBase {
                         CK_ADD_ATTACHMENT, "Include more information", true,
                         "Add structured information as message attachment")
         );
+        configurationRequest.addField(new NumberField(
+                        CK_ADD_BLITEMS, "Backlog items", 5,
+                        "Number of backlog item descriptions to attach")
+        );
+
         configurationRequest.addField(new BooleanField(
                         CK_SHORT_MODE, "Short mode", false,
                         "Enable short mode? This strips down the Slack message to the bare minimum to take less space in the chat room. " +

--- a/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
+++ b/src/main/java/org/graylog2/plugins/slack/SlackPluginMetadata.java
@@ -32,7 +32,7 @@ public class SlackPluginMetadata implements PluginMetaData {
 
     @Override
     public Version getVersion() {
-        return new Version(2, 2, 0, "SNAPSHOT");
+        return new Version(2, 2, 3, "SNAPSHOT");
     }
 
     @Override

--- a/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
+++ b/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
@@ -53,7 +53,7 @@ public class SlackAlarmCallback extends SlackPluginBase implements AlarmCallback
         );
 
         // Add attachments if requested.
-        final List<Message> backlog_items = getAlarmBacklog(result);
+        final List<Message> backlogItems = getAlarmBacklog(result);
 
         if(configuration.getBoolean(CK_ADD_ATTACHMENT)) {
             message.addAttachment(new SlackMessage.AttachmentField("Stream ID", stream.getId(), true));
@@ -64,20 +64,16 @@ public class SlackAlarmCallback extends SlackPluginBase implements AlarmCallback
             if(count < 1){
                 count = 5; //Default items to show
             }
-            final int bl_size = backlog_items.size();
-            if(bl_size < count){
-                count = bl_size;
+            final int blSize = backlogItems.size();
+            if(blSize < count){
+                count = blSize;
             }
+            final StringBuilder sb = new StringBuilder();
             for (int i = 0; i < count; i++) {
-                final String msg = backlog_items.get(i).getMessage();
-                if(msg != null){
-                    if (msg.length() > 512) {
-                        message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg.substring(0, 512), false));
-                    } else {
-                        message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg, false));
-                    }
-                }
+                sb.append(backlogItems.get(i).getMessage()).append("\n\n");
             }
+            String attachmentName = "Backlog Items ("+Integer.toString(count)+")";
+            message.addAttachment(new SlackMessage.AttachmentField(attachmentName, sb.toString(), false));
         }
 
         try {

--- a/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
+++ b/src/main/java/org/graylog2/plugins/slack/callback/SlackAlarmCallback.java
@@ -59,12 +59,23 @@ public class SlackAlarmCallback extends SlackPluginBase implements AlarmCallback
             message.addAttachment(new SlackMessage.AttachmentField("Stream ID", stream.getId(), true));
             message.addAttachment(new SlackMessage.AttachmentField("Stream Title", stream.getTitle(), false));
             message.addAttachment(new SlackMessage.AttachmentField("Stream Description", stream.getDescription(), false));
-            for (Message logMessage : backlog_items) {
-                final String msg = logMessage.getMessage();
-                if (msg.length() > 512) {
-                    message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg.substring(0, 512), false));
-                } else {
-                    message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg, false));
+            
+            int count = configuration.getInt(CK_ADD_BLITEMS);
+            if(count < 1){
+                count = 5; //Default items to show
+            }
+            final int bl_size = backlog_items.size();
+            if(bl_size < count){
+                count = bl_size;
+            }
+            for (int i = 0; i < count; i++) {
+                final String msg = backlog_items.get(i).getMessage();
+                if(msg != null){
+                    if (msg.length() > 512) {
+                        message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg.substring(0, 512), false));
+                    } else {
+                        message.addAttachment(new SlackMessage.AttachmentField("Backlog Summary", msg, false));
+                    }
                 }
             }
         }


### PR DESCRIPTION
I've added "Backlog Summary" items for each message in the alert.
<img width="712" alt="screen shot 2016-07-30 at 0 43 30" src="https://cloud.githubusercontent.com/assets/2025820/17266364/144b2526-55ef-11e6-9d58-5eb41b85108b.png">
